### PR TITLE
[Fixed]: Use the latest user config from the DB in `auth` middleware

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,13 +1,16 @@
 const jwt = require("jsonwebtoken");
 const config = require("config");
 
-function auth(req, res, next) {
+const { getByEmail } = require("../models/user");
+
+async function auth(req, res, next) {
   const token = req.header("x-auth-token");
   if (!token) return res.status(401).send("Not authorized");
 
   try {
     const decoded = jwt.verify(token, config.get("jwtprivatekey"));
-    req.user = decoded;
+    const user = await getByEmail(decoded.email);
+    req.user = user;
     next();
   } catch (error) {
     res.status(400).send("Invalid token");


### PR DESCRIPTION
Previously I was using the decoded token user config which shouldn't not been done, so made this PR to fix it!